### PR TITLE
Add cron trigger support

### DIFF
--- a/runner_lib/Cargo.toml
+++ b/runner_lib/Cargo.toml
@@ -26,3 +26,4 @@ tokio-stream = "0.1.12"
 tokio-tar = "0.3.0"
 uuid = { version = "1.3.0", features = ["v4"] }
 dynconf = { path = "../dynconf" }
+cron_tab = { version = "0.2", features = ["sync", "async"] }

--- a/runner_lib/src/call_context.rs
+++ b/runner_lib/src/call_context.rs
@@ -90,6 +90,7 @@ impl CallContext {
         if let Some(run_context) = self.run_context.as_ref() {
             state.set(run_context.as_ref());
         }
+        state.set(self);
         f(state).await
     }
 


### PR DESCRIPTION
This PR introduces cron-based triggers to the runner by adding native cron support across actions, events, and project configuration.

- Added `Cron` trigger support to `TriggerType` and `Event` enums
- Integrated `cron_tab` as a dependency and initialized a cron engine per project
- Extended `ProjectInfo` with a `cron_engine` field and lifecycle handling
- Implemented cron job creation in `Actions`, allowing scheduled triggers to invoke pipelines
- Fixed call context state assignment to ensure proper trigger execution

This change enables scheduling actions using cron expressions, allowing pipelines to be executed automatically at specified times without external schedulers.

closes: #1